### PR TITLE
fix: add .npmrc so npm installs will always use --legacy-peer-deps flag

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,1 @@
+legacy-peer-deps = true


### PR DESCRIPTION
* [x] This pull request has been tested by running `npm run test` without errors
* [x] This pull request has been built by running `npm run build` without errors
* [x] This isn't a duplicate of an existing pull request

## Description

Resolves CI install issue with legacy peer deps.

## Steps to test

1. Run `npm ci`.

**Expected behavior:** Dependencies install without issue.

## Additional information

See: https://github.com/inclusive-design/idrc/pull/612#issuecomment-1589868718

## Related issues

https://github.com/inclusive-design/idrc/pull/612